### PR TITLE
Resolve real client IP and set it as query.client-ip evidence

### DIFF
--- a/includes/client-ip.php
+++ b/includes/client-ip.php
@@ -1,0 +1,54 @@
+<?php
+/*
+    This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+    Copyright 2019 51 Degrees Mobile Experts Limited, 5 Charlotte Close,
+    Caversham, Reading, Berkshire, United Kingdom RG4 7BY.
+
+    This Original Work is licensed under the European Union Public Licence (EUPL)
+    v.1.2 and is subject to its terms as set out below.
+
+    If a copy of the EUPL was not distributed with this file, You can obtain
+    one at https://opensource.org/licenses/EUPL-1.2.
+
+    The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+    amended by the European Commission) shall be deemed incompatible for
+    the purposes of the Work and the provisions of the compatibility
+    clause in Article 5 of the EUPL shall not apply.
+*/
+
+require_once __DIR__ . '/../options.php';
+
+class ClientIpResolver
+{
+    private const HEADER_MAP = [
+        'cloudflare'   => 'HTTP_CF_CONNECTING_IP',
+        'true-client'  => 'HTTP_TRUE_CLIENT_IP',
+        'x-real-ip'    => 'HTTP_X_REAL_IP',
+        'x-forwarded'  => 'HTTP_X_FORWARDED_FOR',
+        'client-ip'    => 'HTTP_CLIENT_IP',
+    ];
+
+    public static function sanitizeSource($value): string
+    {
+        $allowed = array_merge(['disabled'], array_keys(self::HEADER_MAP));
+        return in_array($value, $allowed, true) ? $value : 'disabled';
+    }
+
+    public static function resolve(?array $server = null): string
+    {
+        $server = $server ?? $_SERVER;
+        $source = get_option(Options::TRUSTED_PROXY_HEADER, 'disabled');
+
+        if (is_string($source) && isset(self::HEADER_MAP[$source]) && !empty($server[self::HEADER_MAP[$source]])) {
+            $raw = $server[self::HEADER_MAP[$source]];
+            $candidate = $source === 'x-forwarded'
+                ? trim(explode(',', $raw, 2)[0])
+                : trim($raw);
+            if (filter_var($candidate, FILTER_VALIDATE_IP)) {
+                return $candidate;
+            }
+        }
+
+        return $server['REMOTE_ADDR'] ?? '';
+    }
+}

--- a/includes/fiftyone-service.php
+++ b/includes/fiftyone-service.php
@@ -166,11 +166,22 @@ class FiftyoneService {
         // This is the Resource Key set by the user to be used to access
         // cloud services.
         add_option(Options::RESOURCE_KEY);
+        // Dropdown selecting which HTTP header (if any) to trust for the
+        // real client IP when the site is behind a reverse proxy or CDN.
+        add_option(Options::TRUSTED_PROXY_HEADER, 'disabled');
 
         // Register the new settings with wordpress.
         register_setting(
             Options::GROUP_KEY,
             Options::RESOURCE_KEY);
+        register_setting(
+            Options::GROUP_KEY,
+            Options::TRUSTED_PROXY_HEADER,
+            [
+                'type' => 'string',
+                'sanitize_callback' => [ClientIpResolver::class, 'sanitizeSource'],
+                'default' => 'disabled',
+            ]);
     }
 
     /**
@@ -279,6 +290,11 @@ class FiftyoneService {
                 delete_option(Options::RESOURCE_KEY_UPDATED);
             }
             
+        }
+
+        if ($option === Options::TRUSTED_PROXY_HEADER &&
+            $new_value !== $old_value) {
+            update_option(Options::SESSION_INVALIDATED, time());
         }
 
         if ($option === Options::GA_TRACKING_ID &&

--- a/includes/pipeline.php
+++ b/includes/pipeline.php
@@ -22,6 +22,7 @@ use fiftyone\pipeline\core\PipelineBuilder;
 use fiftyone\pipeline\core\Utils;
 
 require_once __DIR__ . '/../options.php';
+require_once __DIR__ . '/client-ip.php';
 
 class Pipeline
 {
@@ -151,6 +152,11 @@ class Pipeline
 
             // Set evidence from web request.
             $flowData->evidence->setFromWebRequest();
+
+            $resolvedIp = ClientIpResolver::resolve();
+            if ($resolvedIp !== '') {
+                $flowData->evidence->set('query.client-ip', $resolvedIp);
+            }
 
             // Process flowData with evidence supplied
             try {

--- a/options.php
+++ b/options.php
@@ -50,7 +50,15 @@ class Options
      * Value is stored as an int as returned by time().
      */
     const SESSION_INVALIDATED = "fiftyonedegrees_session_invalidated";
-    
+
+    /**
+     * Key for storing the admin's choice of which HTTP header to read
+     * the real client IP from (for sites behind a reverse proxy or CDN).
+     * Value is one of: 'disabled', 'cloudflare', 'true-client',
+     * 'x-real-ip', 'x-forwarded', 'client-ip'.
+     */
+    const TRUSTED_PROXY_HEADER = "fiftyonedegrees_trusted_proxy_header";
+
 
     /**
      * Key for storing whether or not Google Analytics tracking is

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,6 +14,7 @@
       <file>tests/GaServiceTests.php</file>
       <file>tests/GaTrackingGtagTests.php</file>
       <file>tests/GaHookTests.php</file>
+      <file>tests/ClientIpResolverTests.php</file>
     </testsuite>
     <testsuite name="Integration">
       <file>tests/PipelineTests.php</file>

--- a/setup.php
+++ b/setup.php
@@ -67,6 +67,28 @@
                     <input name="<?php echo Options::RESOURCE_KEY; ?>" type="text" id="<?php echo Options::RESOURCE_KEY; ?>" value="<?php echo esc_attr(get_option(Options::RESOURCE_KEY));?>" class="regular-text">
                 </td>
             </tr>
+            <tr>
+                <th scope="row">
+                    <label for="<?php echo Options::TRUSTED_PROXY_HEADER; ?>">Trusted client-IP source</label>
+                </th>
+                <td>
+                    <?php $current = get_option(Options::TRUSTED_PROXY_HEADER, 'disabled'); ?>
+                    <select name="<?php echo Options::TRUSTED_PROXY_HEADER; ?>" id="<?php echo Options::TRUSTED_PROXY_HEADER; ?>">
+                        <option value="disabled"    <?php selected($current, 'disabled');    ?>>Disabled</option>
+                        <option value="cloudflare"  <?php selected($current, 'cloudflare');  ?>>Cloudflare (CF-Connecting-IP)</option>
+                        <option value="true-client" <?php selected($current, 'true-client'); ?>>Akamai / CF Enterprise (True-Client-IP)</option>
+                        <option value="x-real-ip"   <?php selected($current, 'x-real-ip');   ?>>Nginx (X-Real-IP)</option>
+                        <option value="x-forwarded" <?php selected($current, 'x-forwarded'); ?>>Generic (X-Forwarded-For)</option>
+                        <option value="client-ip"   <?php selected($current, 'client-ip');   ?>>Legacy (Client-IP)</option>
+                    </select>
+                    <p class="description">
+                        Most sites don&#39;t need to change this. If your site sits behind Cloudflare, Nginx, Akamai,
+                        or another service that passes traffic through to WordPress, pick the matching option so visitors
+                        are identified by their real IP address rather than the intermediary&#39;s.
+                        If you&#39;re not sure, leave it set to &quot;Disabled&quot;.
+                    </p>
+                </td>
+            </tr>
         </tbody>
     </table>
 

--- a/tests/ClientIpResolverTests.php
+++ b/tests/ClientIpResolverTests.php
@@ -1,0 +1,288 @@
+<?php
+/*
+    This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+    Copyright 2019 51 Degrees Mobile Experts Limited, 5 Charlotte Close,
+    Caversham, Reading, Berkshire, United Kingdom RG4 7BY.
+
+    This Original Work is licensed under the European Union Public Licence (EUPL)
+    v.1.2 and is subject to its terms as set out below.
+
+    If a copy of the EUPL was not distributed with this file, You can obtain
+    one at https://opensource.org/licenses/EUPL-1.2.
+
+    The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+    amended by the European Commission) shall be deemed incompatible for
+    the purposes of the Work and the provisions of the compatibility
+    clause in Article 5 of the EUPL shall not apply.
+*/
+
+require_once(__DIR__ . "/../includes/client-ip.php");
+require_once(__DIR__ . "/../options.php");
+
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+use \Brain\Monkey\Functions;
+use \Brain\Monkey;
+
+
+class ClientIpResolverTests extends TestCase {
+
+    public function set_up() {
+        parent::set_up();
+        Brain\Monkey\setUp();
+    }
+
+    public function tear_down() {
+        Brain\Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /**
+     * Stub get_option so that Options::TRUSTED_PROXY_HEADER returns
+     * the given value, all other options fall through to their default.
+     */
+    private function mockOption(string $value): void {
+        Functions\when('get_option')->alias(function ($name, $default = null) use ($value) {
+            if ($name === Options::TRUSTED_PROXY_HEADER) {
+                return $value;
+            }
+            return $default;
+        });
+    }
+
+    /**
+     * Test that 'Disabled' source ignores all proxy headers and
+     * returns REMOTE_ADDR.
+     */
+    public function testDisabledReturnsRemoteAddrEvenWhenHeadersPresent() {
+        $this->mockOption('disabled');
+        $this->assertSame('203.0.113.1', ClientIpResolver::resolve([
+            'REMOTE_ADDR' => '203.0.113.1',
+            'HTTP_CF_CONNECTING_IP' => '198.51.100.5',
+            'HTTP_X_FORWARDED_FOR'  => '198.51.100.6',
+        ]));
+    }
+
+    /**
+     * Test that 'Cloudflare' reads CF-Connecting-IP.
+     */
+    public function testCloudflareReadsCfConnectingIp() {
+        $this->mockOption('cloudflare');
+        $this->assertSame('198.51.100.5', ClientIpResolver::resolve([
+            'HTTP_CF_CONNECTING_IP' => '198.51.100.5',
+            'REMOTE_ADDR' => '203.0.113.1',
+        ]));
+    }
+
+    /**
+     * Test that 'Akamai / CF Enterprise' reads True-Client-IP.
+     */
+    public function testTrueClientReadsTrueClientIp() {
+        $this->mockOption('true-client');
+        $this->assertSame('198.51.100.5', ClientIpResolver::resolve([
+            'HTTP_TRUE_CLIENT_IP' => '198.51.100.5',
+            'REMOTE_ADDR' => '203.0.113.1',
+        ]));
+    }
+
+    /**
+     * Test that 'Nginx' reads X-Real-IP.
+     */
+    public function testXRealIpReadsXRealIp() {
+        $this->mockOption('x-real-ip');
+        $this->assertSame('198.51.100.5', ClientIpResolver::resolve([
+            'HTTP_X_REAL_IP' => '198.51.100.5',
+            'REMOTE_ADDR' => '203.0.113.1',
+        ]));
+    }
+
+    /**
+     * Test that 'Generic' reads X-Forwarded-For.
+     */
+    public function testXForwardedReadsXForwardedFor() {
+        $this->mockOption('x-forwarded');
+        $this->assertSame('198.51.100.5', ClientIpResolver::resolve([
+            'HTTP_X_FORWARDED_FOR' => '198.51.100.5',
+            'REMOTE_ADDR' => '203.0.113.1',
+        ]));
+    }
+
+    /**
+     * Test that 'Legacy' reads Client-IP.
+     */
+    public function testClientIpReadsClientIp() {
+        $this->mockOption('client-ip');
+        $this->assertSame('198.51.100.5', ClientIpResolver::resolve([
+            'HTTP_CLIENT_IP' => '198.51.100.5',
+            'REMOTE_ADDR' => '203.0.113.1',
+        ]));
+    }
+
+    /**
+     * Test that a selected source ignores other proxy headers an
+     * attacker may have injected.
+     */
+    public function testCloudflareSelectedIgnoresXForwardedFor() {
+        $this->mockOption('cloudflare');
+        $this->assertSame('198.51.100.5', ClientIpResolver::resolve([
+            'HTTP_CF_CONNECTING_IP' => '198.51.100.5',
+            'HTTP_X_FORWARDED_FOR'  => 'attacker.spoof',
+            'REMOTE_ADDR' => '203.0.113.1',
+        ]));
+    }
+
+    /**
+     * Test that X-Forwarded-For takes the first entry from the
+     * comma-separated list.
+     */
+    public function testXForwardedTakesFirstEntry() {
+        $this->mockOption('x-forwarded');
+        $this->assertSame('203.0.113.1', ClientIpResolver::resolve([
+            'HTTP_X_FORWARDED_FOR' => '203.0.113.1, 10.0.0.1, 10.0.0.2',
+            'REMOTE_ADDR' => '127.0.0.1',
+        ]));
+    }
+
+    /**
+     * Test that whitespace around X-Forwarded-For entries is trimmed.
+     */
+    public function testXForwardedTrimmedWhitespace() {
+        $this->mockOption('x-forwarded');
+        $this->assertSame('203.0.113.1', ClientIpResolver::resolve([
+            'HTTP_X_FORWARDED_FOR' => '  203.0.113.1  , 10.0.0.1',
+            'REMOTE_ADDR' => '127.0.0.1',
+        ]));
+    }
+
+    /**
+     * Test that if the selected header is not present on the request,
+     * the resolver falls back to REMOTE_ADDR.
+     */
+    public function testSelectedHeaderMissingFallsBackToRemoteAddr() {
+        $this->mockOption('cloudflare');
+        $this->assertSame('203.0.113.1', ClientIpResolver::resolve([
+            'REMOTE_ADDR' => '203.0.113.1',
+        ]));
+    }
+
+    /**
+     * Test that a syntactically malformed value in the selected header
+     * triggers fallback to REMOTE_ADDR.
+     */
+    public function testSelectedHeaderMalformedFallsBackToRemoteAddr() {
+        $this->mockOption('cloudflare');
+        $this->assertSame('203.0.113.1', ClientIpResolver::resolve([
+            'HTTP_CF_CONNECTING_IP' => 'not-an-ip',
+            'REMOTE_ADDR' => '203.0.113.1',
+        ]));
+    }
+
+    /**
+     * Test that when XFF is selected and its first entry is malformed,
+     * the resolver falls back to REMOTE_ADDR rather than reading later
+     * entries (which are proxies, not the client).
+     */
+    public function testXForwardedFirstEntryMalformedFallsBackToRemoteAddr() {
+        $this->mockOption('x-forwarded');
+        $this->assertSame('203.0.113.1', ClientIpResolver::resolve([
+            'HTTP_X_FORWARDED_FOR' => 'garbage, 203.0.113.5',
+            'REMOTE_ADDR' => '203.0.113.1',
+        ]));
+    }
+
+    /**
+     * Test that valid IPv6 values in the selected header are accepted
+     * as-is.
+     */
+    public function testIpv6Accepted() {
+        $this->mockOption('cloudflare');
+        $this->assertSame('2001:4860:4860::8888', ClientIpResolver::resolve([
+            'HTTP_CF_CONNECTING_IP' => '2001:4860:4860::8888',
+            'REMOTE_ADDR' => '203.0.113.1',
+        ]));
+    }
+
+    /**
+     * Test that private-range IPs (e.g. 10.0.0.1) in the selected
+     * header are accepted without filtering.
+     */
+    public function testPrivateIpAcceptedWhenChosenSourceProvidesIt() {
+        $this->mockOption('x-real-ip');
+        $this->assertSame('10.0.0.1', ClientIpResolver::resolve([
+            'HTTP_X_REAL_IP' => '10.0.0.1',
+            'REMOTE_ADDR' => '203.0.113.1',
+        ]));
+    }
+
+    /**
+     * Test that when neither a selected header nor REMOTE_ADDR is
+     * available, the resolver returns an empty string.
+     */
+    public function testEmptyServerReturnsEmptyString() {
+        $this->mockOption('disabled');
+        $this->assertSame('', ClientIpResolver::resolve([]));
+    }
+
+    /**
+     * Test that REMOTE_ADDR is returned without FILTER_VALIDATE_IP
+     * (it is server-controlled, not client-forgeable).
+     */
+    public function testRemoteAddrPassesThroughWithoutValidation() {
+        $this->mockOption('disabled');
+        $this->assertSame('anything-goes', ClientIpResolver::resolve([
+            'REMOTE_ADDR' => 'anything-goes',
+        ]));
+    }
+
+    /**
+     * Test that a non-string value from get_option (e.g. null when the
+     * option row is missing in an unmocked test env) is handled
+     * defensively without triggering a deprecation warning.
+     */
+    public function testNonStringOptionValueTreatedAsDisabled() {
+        Functions\when('get_option')->alias(function ($name, $default = null) {
+            return null;
+        });
+        $this->assertSame('203.0.113.1', ClientIpResolver::resolve([
+            'HTTP_CF_CONNECTING_IP' => '198.51.100.5',
+            'REMOTE_ADDR' => '203.0.113.1',
+        ]));
+    }
+
+    /**
+     * Test that a dropdown value not on the sanitizer allow-list is
+     * treated as 'disabled' on read (defence in depth against stale
+     * DB values or direct-DB tampering).
+     */
+    public function testUnknownOptionValueTreatedAsDisabled() {
+        $this->mockOption('something-the-sanitizer-should-have-rejected');
+        $this->assertSame('203.0.113.1', ClientIpResolver::resolve([
+            'HTTP_CF_CONNECTING_IP' => '198.51.100.5',
+            'REMOTE_ADDR' => '203.0.113.1',
+        ]));
+    }
+
+    // --- sanitizeSource (registered as the register_setting sanitize_callback) ---
+
+    /**
+     * Test that every allow-listed dropdown value survives the
+     * sanitizer unchanged.
+     */
+    public function testSanitizeSourceAcceptsAllAllowedValues() {
+        foreach (['disabled', 'cloudflare', 'true-client', 'x-real-ip', 'x-forwarded', 'client-ip'] as $value) {
+            $this->assertSame($value, ClientIpResolver::sanitizeSource($value));
+        }
+    }
+
+    /**
+     * Test that values not on the allow-list are coerced to 'disabled',
+     * preventing arbitrary $_SERVER keys from reaching the resolver.
+     */
+    public function testSanitizeSourceRejectsUnknownValues() {
+        $this->assertSame('disabled', ClientIpResolver::sanitizeSource('CLOUDFLARE'));
+        $this->assertSame('disabled', ClientIpResolver::sanitizeSource('HTTP_X_FORWARDED_FOR'));
+        $this->assertSame('disabled', ClientIpResolver::sanitizeSource(''));
+        $this->assertSame('disabled', ClientIpResolver::sanitizeSource(null));
+        $this->assertSame('disabled', ClientIpResolver::sanitizeSource([]));
+        $this->assertSame('disabled', ClientIpResolver::sanitizeSource(42));
+    }
+}

--- a/tests/PipelineTests.php
+++ b/tests/PipelineTests.php
@@ -28,14 +28,21 @@ use \Brain\Monkey\Filters;
 
 class PipelineTests extends TestCase {
 
+    private $serverBackup;
+    private $getBackup;
+
     public function set_up() {
         Pipeline::reset();
         parent::set_up();
         Brain\Monkey\setUp();
         $_SESSION = null;
+        $this->serverBackup = $_SERVER;
+        $this->getBackup = $_GET;
     }
 
     public function tear_down() {
+        $_SERVER = $this->serverBackup;
+        $_GET = $this->getBackup;
         Brain\Monkey\tearDown();
         parent::tear_down();
     }
@@ -447,5 +454,118 @@ class PipelineTests extends TestCase {
 
         $this->assertNotNull($capturedPipeline);
         $this->assertArrayHasKey('pipeline', $capturedPipeline);
+    }
+
+    /**
+     * Test that on a fresh install (dropdown 'disabled'),
+     * Pipeline::process sets query.client-ip to REMOTE_ADDR.
+     */
+    public function testProcess_SetsResolvedClientIpAsQueryEvidence() {
+        Functions\when('get_site_url')->justReturn('http://localhost/testsite');
+        Functions\when('rest_url')->justReturn('http://localhost/testsite/wp-json/fiftyonedegrees/v4/json');
+
+        $resourceKey = $_ENV["RESOURCEKEY"];
+        if ($resourceKey === "!!YOUR_RESOURCE_KEY!!") {
+            $this->fail("Resource Key required; set RESOURCEKEY env or .env");
+        }
+
+        $_SERVER['REMOTE_ADDR'] = '203.0.113.1';
+        $pipeline = Pipeline::make_pipeline($resourceKey);
+        Functions\when('get_option')->alias(function ($name, $default = null) use ($pipeline) {
+            if ($name === Options::PIPELINE) return $pipeline;
+            if ($name === Options::TRUSTED_PROXY_HEADER) return 'disabled';
+            return $default;
+        });
+
+        Pipeline::process();
+
+        $flowData = Pipeline::$data['flowData'];
+        $this->assertSame('203.0.113.1', $flowData->evidence->get('query.client-ip'));
+        $this->assertSame('203.0.113.1', $flowData->evidence->get('server.client-ip'));
+    }
+
+    /**
+     * Test that a URL-supplied ?client-ip is overwritten by the
+     * resolver, preventing visitors from spoofing the cloud-detected IP.
+     */
+    public function testProcess_QueryStringClientIpIsOverriddenByResolver() {
+        Functions\when('get_site_url')->justReturn('http://localhost/testsite');
+        Functions\when('rest_url')->justReturn('http://localhost/testsite/wp-json/fiftyonedegrees/v4/json');
+
+        $resourceKey = $_ENV["RESOURCEKEY"];
+        if ($resourceKey === "!!YOUR_RESOURCE_KEY!!") {
+            $this->fail("Resource Key required; set RESOURCEKEY env or .env");
+        }
+
+        $_SERVER['REMOTE_ADDR'] = '203.0.113.1';
+        $_GET['client-ip'] = 'attacker.ip.spoof';
+        $pipeline = Pipeline::make_pipeline($resourceKey);
+        Functions\when('get_option')->alias(function ($name, $default = null) use ($pipeline) {
+            if ($name === Options::PIPELINE) return $pipeline;
+            if ($name === Options::TRUSTED_PROXY_HEADER) return 'disabled';
+            return $default;
+        });
+
+        Pipeline::process();
+
+        $flowData = Pipeline::$data['flowData'];
+        $this->assertSame(
+            '203.0.113.1',
+            $flowData->evidence->get('query.client-ip'),
+            'URL-supplied client-ip must not reach the cloud'
+        );
+    }
+
+    /**
+     * Test that when the resolver returns '' (REMOTE_ADDR absent),
+     * Pipeline::process does not set query.client-ip — the cloud
+     * treats an empty client-ip as broken input.
+     */
+    public function testProcess_EmptyResolvedIpDoesNotPollute() {
+        Functions\when('get_site_url')->justReturn('http://localhost/testsite');
+        Functions\when('rest_url')->justReturn('http://localhost/testsite/wp-json/fiftyonedegrees/v4/json');
+
+        $resourceKey = $_ENV["RESOURCEKEY"];
+        if ($resourceKey === "!!YOUR_RESOURCE_KEY!!") {
+            $this->fail("Resource Key required; set RESOURCEKEY env or .env");
+        }
+
+        $_SERVER = [];
+        $_GET = [];
+        $pipeline = Pipeline::make_pipeline($resourceKey);
+        Functions\when('get_option')->alias(function ($name, $default = null) use ($pipeline) {
+            if ($name === Options::PIPELINE) return $pipeline;
+            if ($name === Options::TRUSTED_PROXY_HEADER) return 'disabled';
+            return $default;
+        });
+
+        Pipeline::process();
+
+        $flowData = Pipeline::$data['flowData'];
+        $this->assertNull($flowData->evidence->get('query.client-ip'));
+    }
+
+    /**
+     * Test that changing TRUSTED_PROXY_HEADER via update_option bumps
+     * SESSION_INVALIDATED so the session cache re-processes on the
+     * next request.
+     */
+    public function testUpdateOptionBumpsSessionInvalidationOnHeaderChange() {
+        $bumped = false;
+        Functions\when('update_option')->alias(function ($name, $value) use (&$bumped) {
+            if ($name === Options::SESSION_INVALIDATED && is_int($value)) {
+                $bumped = true;
+            }
+            return true;
+        });
+
+        $service = new FiftyoneService();
+        $service->fiftyonedegrees_update_option(
+            Options::TRUSTED_PROXY_HEADER,
+            'disabled',
+            'cloudflare'
+        );
+
+        $this->assertTrue($bumped, 'SESSION_INVALIDATED was not bumped on header change');
     }
 }


### PR DESCRIPTION
Adds a Setup-tab dropdown letting admins pick which proxy header carries the real visitor IP (Cloudflare, Nginx, Akamai, X-Forwarded-For, or Client-IP); value is injected into the pipeline before processing so the cloud sees the correct IP behind reverse proxies and CDNs.

Implements #19 